### PR TITLE
Set up DevConfiguration package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# DevConfiguration Changelog
+
+
+## 1.0.0 – TBD
+
+Description forthcoming.

--- a/Documentation/MarkdownStyleGuide.md
+++ b/Documentation/MarkdownStyleGuide.md
@@ -1,0 +1,190 @@
+# Markdown Style Guide
+
+This document defines the Markdown formatting standards for documentation in the DevConfiguration
+codebase.
+
+
+## General Formatting
+
+### Line Length
+
+Keep all lines under **100 characters**. Break long sentences and paragraphs at natural points
+to stay within this limit.
+
+    ✅ Good:
+    Faucibus consectetur lacinia nostra eros conubia nibh inceptos hendrerit, ante blandit 
+    vulputate imperdiet amet porttitor torquent mattis.
+    
+    ❌ Bad:
+    Faucibus consectetur lacinia nostra eros conubia nibh inceptos hendrerit, ante blandit vulputate imperdiet amet porttitor torquent mattis.
+
+
+### Spacing
+
+Use consistent spacing for visual hierarchy:
+
+- **Between major sections**: 2 blank lines
+- **After code blocks**: 1 blank line
+- **Before subsections**: 1 blank line
+- **After section headers**: 1 blank line
+
+Example:
+
+    ## Major Section
+
+    Content here.
+
+
+    ## Another Major Section
+
+    ### Subsection
+
+    Content after subsection header.
+
+        code block here
+
+    Content after code block.
+
+
+## Headers
+
+### Structure
+
+Use consistent header hierarchy:
+
+  - `#` for document title
+  - `##` for major sections
+  - `###` for subsections
+  - `####` for sub-subsections (use sparingly)
+
+### Numbering
+
+Number subsections when they represent sequential steps or ordered items:
+
+    ## Usage Patterns
+
+    ### 1. Basic Setup
+    ### 2. Advanced Configuration
+    ### 3. Verification
+
+
+## Code Blocks
+
+### Indented Code Blocks
+
+Use **4-space indentation** for all code blocks instead of fenced blocks:
+
+    ✅ Good:
+        import DevTesting
+
+        final class MockService: ServiceProtocol {
+            nonisolated(unsafe) var performActionStub: Stub<String, Bool>!
+        }
+
+    ❌ Bad:
+    ```swift
+    import DevTesting
+
+    final class MockService: ServiceProtocol {
+        nonisolated(unsafe) var performActionStub: Stub<String, Bool>!
+    }
+    ```
+
+
+## Lists
+
+### Unordered Lists
+
+Use `-` as the bullet character for unordered lists. Place the hyphen 2 spaces from current
+indentation level, followed by a space, then your text. When a bullet point spans multiple lines,
+align continuation lines with the start of the text (not the hyphen). This ensures all text within a
+bullet aligns vertically and makes proper indentation on continuation lines a matter of pressing tab
+one or more times.
+
+      - Turpis cubilia sit urna dis ultricies consequat massa hendrerit enim natoque.
+      - Consectetur sapien posuere sit arcu finibus mattis dictumst dis, lectus ipsum in dictum
+        lobortis bibendum enim, suscipit aliquet nulla porta erat id class purus.
+          - Scelerisque massa rutrum dapibus placerat aenean tellus arcu cursus.
+          - Iaculis, cubilia tristique efficitur bibendum urna imperdiet facilisis turpis hac,
+            platea est habitant auctor quisque nec pulvinar fermentum sociosqu.
+          - Parturient justo, venenatis nunc lobortis senectus tortor orci elementum consequat.
+      - In nibh nisl venenatis bibendum neque mattis habitant tempor proin, tincidunt lobortis
+        vulputate commodo.
+
+Blank lines can be placed between bullets if it aids in readability.
+
+### Ordered Lists
+
+Use standard numbered lists for sequential items. Follow similar indentation rules as for unordered
+lists. Note that the `.` characters in the bullets leads to some strange indentation, but this is
+unavoidable.
+
+      1. Turpis cubilia sit urna dis ultricies consequat massa hendrerit enim natoque.
+
+      2. Consectetur sapien posuere sit arcu finibus mattis dictumst dis, lectus ipsum in dictum
+         lobortis bibendum enim, suscipit aliquet nulla porta erat id class purus.
+
+          1. Scelerisque massa rutrum dapibus placerat aenean tellus arcu cursus.
+          2. Iaculis, cubilia tristique efficitur bibendum urna imperdiet facilisis turpis hac,
+             platea est habitant auctor quisque nec pulvinar fermentum sociosqu.
+          3. Parturient justo, venenatis nunc lobortis senectus tortor orci elementum consequat.
+
+      4. In nibh nisl venenatis bibendum neque mattis habitant tempor proin, tincidunt lobortis
+         vulputate commodo.
+
+
+## Text Formatting
+
+### Bold Text
+
+Use bold for emphasis on key terms:
+
+  - **File names**: `Mock[ProtocolName].swift`
+  - **Type names**: `Mock[ProtocolName]`
+
+### Code Spans
+
+Use backticks for:
+
+  - Type names: `Stub<Input, Output>`
+  - Function names: `performAction(_:)`
+  - File names: `MockAppServices.swift`
+  - Keywords: `nonisolated(unsafe)`
+
+### Terminology Consistency
+
+Use consistent terminology throughout documents:
+
+- Prefer "function" over "method" when referring to Swift functions
+- Use "type" instead of "class" when referring generically to classes/structs/enums
+- Use "property" for stored and computed properties
+
+
+## File Structure Examples
+
+Use indented text blocks for file structure diagrams:
+
+    Tests/
+    ├── Folder 1/
+    │   └── Folder 2/
+    │       ├── File1.swift
+    │       └── File2.swift
+    └── Folder 3/
+        └── Folder 4/
+            ├── File3.swift
+            └── File4.swift
+
+
+## Links and References
+
+### Internal References
+
+Use relative paths for internal documentation:
+
+    See [Test Mock Documentation](TestMocks.md) for details.
+
+### Code References
+
+Reference specific locations using this pattern:
+
+    The main implementation is in `Stub.swift:42-68`.

--- a/Documentation/TestMocks.md
+++ b/Documentation/TestMocks.md
@@ -1,0 +1,275 @@
+# Test Mock Documentation
+
+This document outlines the patterns and conventions for writing test mocks in the DevConfiguration
+codebase.
+
+
+## Overview
+
+The codebase uses a consistent approach to mocking based on the DevTesting framework's `Stub` type.
+All mocks follow standardized patterns that make them predictable, testable, and maintainable.
+
+
+## Core Mock Patterns
+
+### 1. Stub-Based Architecture
+
+All mocks use `DevTesting`’s `Stub<Input, Output>` or `ThrowingStub<Input, Output, Error>` types
+for function and property implementations:
+
+    import DevTesting
+
+
+    final class MockService: ServiceProtocol {
+        nonisolated(unsafe)
+        var performActionStub: Stub<String, Bool>!
+
+
+        func performAction(_ input: String) -> Bool {
+            performActionStub(input)
+        }
+    }
+
+**Key characteristics:**
+
+  - Properties are marked `nonisolated(unsafe)` for Swift 6 concurrency
+  - Stub properties are force-unwrapped (`!`). Tests must configure them.
+  - Function implementations simply call the corresponding stub
+
+
+### 2. Argument Structures for Complex Parameters
+
+When functions have multiple parameters, create dedicated argument structures:
+
+    final class MockTelemetryDestination: TelemetryDestination {
+        struct LogErrorArguments {
+            let error: any Error
+            let attributes: [String : any Encodable]
+        }
+
+
+        nonisolated(unsafe)
+        var logErrorStub: Stub<LogErrorArguments, Void>!
+
+
+        func logError(_ error: some Error, attributes: [String : any Encodable]) {
+            logErrorStub(.init(error: error, attributes: attributes))
+        }
+    }
+
+**Benefits:**
+
+  - Simplifies stub configuration in tests
+  - Provides clear parameter documentation
+  - Enables easy verification of function calls
+
+
+### 3. Property-Only Services
+
+For services that only expose properties (like `MockAppServices`), each property delegates to a
+stub:
+
+    final class MockAppServices: PlatformAppServices {
+        nonisolated(unsafe)
+        var stylesheetStub: Stub<Void, Stylesheet>!
+
+        nonisolated(unsafe)
+        var telemetryEventLoggerStub: Stub<Void, any TelemetryEventLogging>!
+
+
+        var stylesheet: Stylesheet {
+            stylesheetStub()
+        }
+
+
+        var telemetryEventLogger: any TelemetryEventLogging {
+            telemetryEventLoggerStub()
+        }
+    }
+
+
+### 4. Generic Mock Types
+
+For protocols with associated types, create generic mocks:
+
+    struct MockTelemetryEvent<EventData>: TelemetryEvent
+    where EventData: Encodable & Sendable {
+        let name: TelemetryEventName
+        var eventData: EventData
+    }
+
+    extension MockTelemetryEvent: Equatable where EventData: Equatable { }
+    extension MockTelemetryEvent: Hashable where EventData: Hashable { }
+
+
+**Pattern:**
+
+  - Use generic parameters for flexible data types
+  - Add conditional conformances for `Equatable` and `Hashable` when possible
+  - Maintain protocol requirements while allowing test customization
+
+
+### 5. Simple Error Mocks
+
+For testing error scenarios, use simple enum-based errors:
+
+    enum MockError: Error, CaseIterable, Hashable, Sendable {
+        case error1
+        case error2
+        case error3
+    }
+
+**Characteristics:**
+
+  - Implement `CaseIterable` for easy test iteration
+  - Include `Hashable` and `Sendable` for Swift 6 compatibility
+  - Use descriptive but simple case names
+
+
+## Mock Organization
+
+### File Structure
+
+    Tests/
+    ├── AppPlatformTests/
+    │   └── Testing Support/
+    │       ├── MockAppServices.swift
+    │       ├── MockBootstrapper.swift
+    │       └── MockSubapp.swift
+    └── TelemetryTests/
+        └── Testing Support/
+            ├── MockTelemetryDestination.swift
+            ├── MockTelemetryEvent.swift
+            └── MockError.swift
+
+
+### Naming Conventions
+
+  - **File names**: `Mock[ProtocolName].swift`
+  - **Type names**: `Mock[ProtocolName]`
+  - **Argument structures**: `[FunctionName]Arguments`
+  - **Stub properties**: `[functionName]Stub`
+
+
+## Special Patterns
+
+### 1. Static Stubs for Initializers
+
+When mocking types with custom initializers, use static stubs:
+
+    final class MockSubapp: Subapp {
+        struct InitArguments {
+            let appConfiguration: AppConfiguration
+            let subappServices: any SubappServices
+        }
+
+
+        nonisolated(unsafe)
+        static var initStub: Stub<InitArguments, Void>!
+
+
+        init(appConfiguration: AppConfiguration, subappServices: any SubappServices) async {
+            Self.initStub(.init(appConfiguration: appConfiguration, subappServices: subappServices))
+        }
+    }
+
+
+### 2. Default Stub Values
+
+For functions that might not be called in every test, provide default stub values:
+
+    final class MockSubapp: Subapp {
+        // Initialize to non-nil to avoid crashes in tests that don't configure this stub
+        nonisolated(unsafe)
+        var installTelemetryBusEventHandlersStub: Stub<TelemetryBusEventObserver, Void> = .init()
+    }
+
+
+### 3. Protocol Imports with @testable
+
+Import protocols under test with `@testable` when accessing internal details:
+
+    import AppPlatform
+    @testable import protocol AppPlatform.PlatformAppServices
+    @testable import protocol Telemetry.TelemetryDestination
+
+
+## Usage in Tests
+
+### 1. Typical Test Setup
+
+    @Test
+    mutating func testEventLogging() throws {
+        let mockDestination = MockTelemetryDestination()
+        mockDestination.logEventStub = .init()  // Initialize stub
+
+        let logger = TelemetryEventLogger(telemetryDestination: mockDestination)
+        logger.logEvent(someEvent)
+
+        // Verify the call was made
+        #expect(mockDestination.logEventStub.calls.count == 1)
+
+        // Extract and verify arguments
+        let arguments = try #require(mockDestination.logEventStub.callArguments.first)
+        #expect(arguments.name == expectedEventName)
+        #expect(arguments.attributes["key"] as? String == "expectedValue")
+    }
+
+
+### 2. Return Value Configuration
+
+    @Test
+    func testServiceCall() {
+        let mockServices = MockAppServices()
+        mockServices.stylesheetStub = Stub(defaultReturnValue: .standard)
+
+        let result = systemUnderTest.processWithServices(mockServices)
+
+        // Verify the service was called
+        #expect(mockServices.stylesheetStub.calls.count == 1)
+    }
+
+
+### 3. Argument Verification Patterns
+
+    @Test
+    mutating func testComplexMethodCall() throws {
+        let mockDestination = MockTelemetryDestination()
+        mockDestination.logErrorStub = .init()
+
+        let error = MockError.error1
+        let attributes = ["key": "value"]
+
+        logger.logError(error, attributes: attributes)
+
+        // Verify call count
+        #expect(mockDestination.logErrorStub.calls.count == 1)
+
+        // Extract and verify arguments
+        let arguments = try #require(mockDestination.logErrorStub.callArguments.first)
+        #expect(arguments.error as? MockError == error)
+        #expect(arguments.attributes["key"] as? String == "value")
+    }
+
+
+## Best Practices
+
+  1. **Always configure stubs**: Force-unwrapped stubs will crash if not configured
+  2. **Use argument structures**: Simplifies complex parameter verification
+  3. **Maintain protocol fidelity**: Mocks should behave like real implementations
+  4. **Leverage DevTesting**: Use the framework's call tracking and verification capabilities
+  5. **Keep mocks simple**: Avoid complex logic in mock implementations
+  6. **Group related mocks**: Place mocks in appropriate Testing Support directories
+  7. **Follow naming conventions**: Consistent naming improves maintainability
+  8. **Use Swift Testing**: Leverage `@Test`, `#expect()`, and `#require()` for assertions
+
+
+## Thread Safety
+
+All mocks use `nonisolated(unsafe)` markings for Swift 6 compatibility. This assumes:
+
+  - Tests run on a single thread or properly synchronize access
+  - Stub configuration happens during test setup before concurrent access
+  - Mock usage patterns don't require additional synchronization
+
+When mocking concurrent code, consider additional synchronization mechanisms if needed.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,18 @@
+# MIT License
+
+Copyright © 2025 Prachi Gauriar
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "222f113614d29faab34495fcc0b3117443743f1bed9ee6a27b0e343febfa0c14",
+  "pins" : [
+    {
+      "identity" : "devtesting",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/DevKitOrganization/DevTesting",
+      "state" : {
+        "revision" : "32dd16262b17b291279adda9cfc7dd683ed7e6ee",
+        "version" : "1.0.0-beta.7"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,41 @@
+// swift-tools-version: 6.1
+
+import PackageDescription
+
+let swiftSettings: [SwiftSetting] = [
+    .enableUpcomingFeature("ExistentialAny")
+]
+
+let package = Package(
+    name: "DevConfiguration",
+    platforms: [
+        .iOS(.v18),
+        .macOS(.v15),
+        .tvOS(.v18),
+        .visionOS(.v2),
+        .watchOS(.v11),
+    ],
+    products: [
+        .library(
+            name: "DevConfiguration",
+            targets: ["DevConfiguration"]
+        ),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/DevKitOrganization/DevTesting", from: "1.0.0-beta.7"),
+    ],
+    targets: [
+        .target(
+            name: "DevConfiguration",
+            swiftSettings: swiftSettings
+        ),
+        .testTarget(
+            name: "DevConfigurationTests",
+            dependencies: [
+                "DevConfiguration",
+                "DevTesting",
+            ],
+            swiftSettings: swiftSettings
+        ),
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# DevConfiguration
+
+Description forthcoming.
+
+DevConfiguration is fully documented and tested and supports iOS 18+, macOS 15+, tvOS 18+, visionOS 2+,
+and watchOS 11+.
+
+View our [changelog](CHANGELOG.md) to see what’s new.
+
+
+## Development Requirements
+
+DevConfiguration requires a Swift 6.1 toolchain to build. We only test on Apple platforms. We follow
+the [Swift API Design Guidelines][SwiftAPIDesignGuidelines]. We take pride in the fact that our
+public interfaces are fully documented and tested. We aim for overall test coverage over 99%.
+
+[SwiftAPIDesignGuidelines]: https://swift.org/documentation/api-design-guidelines/
+
+### Development Setup
+
+To set up the development environment:
+
+  1. Run `Scripts/install-git-hooks` to install pre-commit hooks that automatically check code
+    formatting.
+  2. Use `Scripts/lint` to manually check code formatting at any time.
+
+
+## Bugs and Feature Requests
+
+Find a bug? Want a new feature? Create a GitHub issue and we’ll take a look.
+
+
+## License
+
+All code is licensed under the MIT license. Do with it as you will.

--- a/Sources/DevConfiguration/DevConfiguration.swift
+++ b/Sources/DevConfiguration/DevConfiguration.swift
@@ -1,0 +1,17 @@
+//
+//  DevConfiguration.swift
+//  DevConfiguration
+//
+//  Created by Duncan Lewis on 6/11/25.
+//
+
+import Foundation
+
+/// Prepends the specified string with `"com.gauriar.devconfiguration."`.
+///
+/// - Parameter suffix: The string that will have DevConfiguration’s reverse DNS prefix prepended
+///   to it.
+@usableFromInline
+func reverseDNSPrefixed(_ suffix: String) -> String {
+    return "com.gauriar.devconfiguration.\(suffix)"
+}


### PR DESCRIPTION
# Overview
Sets up the DevConfiguration package with a:

  - Changelog
  - Standard guides for formatting Markdown and writing Test Mocks
  - MIT License
  - Swift Package file
  - Readme
  - Placeholder Swift file containing a reverseDNSPrefix helper