### PR TITLE
Fix small typos in DocC documentation

### DIFF
--- a/Sources/DevConfiguration/Core/ConfigVariableReader.swift
+++ b/Sources/DevConfiguration/Core/ConfigVariableReader.swift
@@ -17,13 +17,12 @@ import Synchronization
 /// The reader integrates with an access reporter to provide telemetry and observability for all configuration access.
 ///
 /// To use a config variable reader, first define your configuration variables using ``ConfigVariable``. Each variable
-/// specifies its key, type, default value, and secrecy level:
+/// specifies its key, type, and default value:
 ///
 ///     extension ConfigVariable where Value == Bool {
-///         static let darkMode = ConfigVariable(
-///             key: "dark_mode",
-///             defaultValue: false,
-///             secrecy: .auto
+///         static let isDarkModeEnabled = ConfigVariable(
+///             key: "dark_mode_enabled",
+///             defaultValue: false
 ///         )
 ///     }
 ///
@@ -31,12 +30,13 @@ import Synchronization
 ///
 ///     let reader = ConfigVariableReader(
 ///         namedProviders: [
-///             .init(InMemoryProvider(values: ["dark_mode": "true"]), displayName: "In-Memory")
+///             .init(InMemoryProvider(values: ["dark_mode_enabled": "true"]), displayName: "In-Memory"),
+///             .init(EnvironmentVariablesProvider(), displayName: "Environment"),
 ///         ],
 ///         eventBus: eventBus
 ///     )
 ///
-///     let darkMode = reader[.darkMode]  // true
+///     let isDarkModeEnabled = reader[.isDarkModeEnabled]  // true
 ///
 /// The reader never throws. If resolution fails, it returns the variable’s default value and posts a
 /// ``ConfigVariableAccessFailedEvent`` to the event bus.

--- a/Sources/DevConfiguration/Metadata/ConfigVariableMetadata.swift
+++ b/Sources/DevConfiguration/Metadata/ConfigVariableMetadata.swift
@@ -19,15 +19,15 @@ import Foundation
 /// Define custom metadata keys by creating types conforming to ``ConfigVariableMetadataKey`` and extending
 /// `ConfigVariableMetadata` with convenience properties:
 ///
-///     private struct ProjectMetadataKey: ConfigVariableMetadataKey {
+///     private struct ProjectNameMetadataKey: ConfigVariableMetadataKey {
 ///         static let defaultValue: String? = nil
 ///         static let keyDisplayText = "Project"
 ///     }
 ///
 ///     extension ConfigVariableMetadata {
-///         var project: String? {
-///             get { self[ProjectMetadataKey.self] }
-///             set { self[ProjectMetadataKey.self] = newValue }
+///         var projectName: String? {
+///             get { self[ProjectNameMetadataKey.self] }
+///             set { self[ProjectNameMetadataKey.self] = newValue }
 ///         }
 ///     }
 ///
@@ -122,7 +122,7 @@ public struct ConfigVariableMetadata: Hashable, Sendable {
 /// To define a new metadata key, create a private type that conforms to `ConfigVariableMetadataKey` and implement the
 /// required properties:
 ///
-///     private struct projectMetadataKey: ConfigVariableMetadataKey {
+///     private struct ProjectNameMetadataKey: ConfigVariableMetadataKey {
 ///         static let defaultValue: String? = nil
 ///         static let keyDisplayText: String = "Project"
 ///     }
@@ -130,9 +130,9 @@ public struct ConfigVariableMetadata: Hashable, Sendable {
 /// Then extend `ConfigVariableMetadata` with a convenience property to access the value:
 ///
 ///     extension ConfigVariableMetadata {
-///         var project: String? {
-///             get { self[ProjectMetadataKey.self] }
-///             set { self[ProjectMetadataKey.self] = newValue }
+///         var projectName: String? {
+///             get { self[ProjectNameMetadataKey.self] }
+///             set { self[ProjectNameMetadataKey.self] = newValue }
 ///         }
 ///     }
 ///


### PR DESCRIPTION
  - Eliminate reference to old secrecy API from ConfigVariableReader
  - Correct example metadata key in ConfigVariableMetadata
